### PR TITLE
cause `list-all` argument to give perl-build versions in opposite order

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,7 @@ source "$(dirname "$0")/utils.sh"
 
 list_all() {
   install_or_update_perl_build
-  $(perl_build_path) --definitions | tr '\n' ' '
+  $(perl_build_path) --definitions | tr '\n' ' ' | tail -r
 }
 
 list_all

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,7 @@ source "$(dirname "$0")/utils.sh"
 
 list_all() {
   install_or_update_perl_build
-  $(perl_build_path) --definitions | tr '\n' ' ' | tail -r
+  $(perl_build_path) --definitions | tac | tr '\n' ' '
 }
 
 list_all


### PR DESCRIPTION
ASDF `latest` arg grabs *last* entry from `list-all` command, meaning that the list of available Perl definitions should be printed in the reverse of the order provided by perl-build (as in, the latest version should come last).