### PR TITLE
Use perl-install rather than Perl-Build, which requires a system perl

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -15,14 +15,14 @@ install_perl() {
     echoerr "For a list of available versions, see \`asdf list-all perl\`."
     exit 1
   fi
-  install_or_update_perl_build
+  install_or_update_perl_install
 
-  local build_args=("-j${concurrency}" -Dusethreads)
+  local build_args=("-j=${concurrency}" -Dusethreads)
   if is_development_version "$version"; then
       build_args+=(-Dusedevel --symlink-devel-executables)
   fi
-  echo "perl-build ${build_args[@]} $version $install_path"
-  $(perl_build_path) "${build_args[@]}" "$version" "$install_path"
+  echo "perl-install ${build_args[@]} $version $install_path"
+  $(perl_install_bin) "${build_args[@]}" "$version" "$install_path"
 }
 
 install_cpanm() {
@@ -75,7 +75,7 @@ is_development_version() {
     return 0
 }
 
-ensure_perl_build_installed
+ensure_perl_install_installed
 install_perl "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
 install_cpanm "$ASDF_INSTALL_PATH"
 install_default_perl_modules

--- a/bin/list-all
+++ b/bin/list-all
@@ -3,8 +3,8 @@
 source "$(dirname "$0")/utils.sh"
 
 list_all() {
-  install_or_update_perl_build
-  $(perl_build_path) --definitions | tac | tr '\n' ' '
+  install_or_update_perl_install
+  $(perl_install_bin) --list-all | tac | tr '\n' ' '
 }
 
 list_all

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -2,32 +2,32 @@ echoerr() {
   printf "\033[0;31m%s\033[0m" "$1" >&2
 }
 
-ensure_perl_build_installed() {
-  if [ ! -f "$(perl_build_path)" ]; then
-    download_perl_build
+ensure_perl_install_installed() {
+  if [ ! -f "$(perl_install_bin)" ]; then
+    download_perl_install
   fi
 }
 
-download_perl_build() {
-  echo "Downloading perl-build..." >&2
-  local perl_build_url="https://github.com/tokuhirom/Perl-Build.git"
-  git clone --depth 1 $perl_build_url "$(perl_build_checkout)"
+download_perl_install() {
+  echo "Downloading perl-install..." >&2
+  local perl_install_url="https://github.com/skaji/perl-install.git"
+  git clone --depth 1 $perl_install_url "$(perl_install_checkout)"
 }
 
-perl_build_checkout() {
-  echo "$(dirname $(dirname $0))/perl-build"
+perl_install_checkout() {
+  echo "$(dirname $(dirname $0))/perl-install"
 }
 
-perl_build_path() {
-  echo "$(perl_build_checkout)/bin/perl-build"
+perl_install_bin() {
+  echo "$(perl_install_checkout)/perl-install"
 }
 
-update_perl_build() {
-  cd "$(perl_build_checkout)" && git fetch && git reset --hard origin/master > /dev/null 2>&1
+update_perl_install() {
+  cd "$(perl_install_checkout)" && git fetch && git reset --hard origin/HEAD > /dev/null 2>&1
 }
 
 update_timestamp_path() {
-  echo "$(perl_build_checkout)/.git/FETCH_HEAD"
+  echo "$(perl_install_checkout)/.git/FETCH_HEAD"
 }
 
 should_update() {
@@ -45,10 +45,10 @@ should_update() {
   [ $invalidated_at -lt $current_timestamp ]
 }
 
-install_or_update_perl_build() {
-  if [ ! -f "$(perl_build_path)" ]; then
-    download_perl_build
+install_or_update_perl_install() {
+  if [ ! -f "$(perl_install_bin)" ]; then
+    download_perl_install
   elif should_update; then
-    update_perl_build
+    update_perl_install
   fi
 }

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -10,31 +10,29 @@ ensure_perl_build_installed() {
 
 download_perl_build() {
   echo "Downloading perl-build..." >&2
-  local plenv_url="https://github.com/tokuhirom/plenv.git"
   local perl_build_url="https://github.com/tokuhirom/Perl-Build.git"
-  git clone $plenv_url "$(plenv_path)"
-  git clone $perl_build_url "$(plenv_path)/plugins/perl-build/"
+  git clone $perl_build_url "$(perl_build_checkout)"
+}
+
+perl_build_checkout() {
+  echo "$(dirname $(dirname $0))/perl-build"
 }
 
 perl_build_path() {
-  echo "$(plenv_path)/plugins/perl-build/bin/perl-build"
+  echo "$(perl_build_checkout)/bin/perl-build"
 }
 
 update_perl_build() {
-  cd "$(plenv_path)" && git fetch && git reset --hard origin/master > /dev/null 2>&1
+  cd "$(perl_build_checkout)" && git fetch && git reset --hard origin/master > /dev/null 2>&1
 }
 
-plenv_path() {
-  echo "$(dirname $(dirname $0))/plenv"
+update_timestamp_path() {
+  echo "$(dirname $(dirname "$0"))/last_update"
 }
 
-plenv_update_timestamp_path() {
-  echo "$(dirname $(dirname "$0"))/plenv_last_update"
-}
-
-plenv_should_update() {
+should_update() {
   update_timeout=3600
-  update_timestamp_path=$(plenv_update_timestamp_path)
+  update_timestamp_path=$(update_timestamp_path)
 
   if [ ! -f "$update_timestamp_path" ]; then
     return 0
@@ -50,8 +48,8 @@ plenv_should_update() {
 install_or_update_perl_build() {
   if [ ! -f "$(perl_build_path)" ]; then
     download_perl_build
-  elif plenv_should_update; then
+  elif should_update; then
     update_perl_build
-    date +%s > "$(plenv_update_timestamp_path)"
+    date +%s > "$(update_timestamp_path)"
   fi
 }

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -27,20 +27,20 @@ update_perl_build() {
 }
 
 update_timestamp_path() {
-  echo "$(dirname $(dirname "$0"))/last_update"
+  echo "$(perl_build_checkout)/.git/FETCH_HEAD"
 }
 
 should_update() {
-  update_timeout=3600
-  update_timestamp_path=$(update_timestamp_path)
+  local update_timeout=3600
+  local update_timestamp_path=$(update_timestamp_path)
 
   if [ ! -f "$update_timestamp_path" ]; then
     return 0
   fi
 
-  last_update=$(cat "$update_timestamp_path")
-  current_timestamp=$(date +%s)
-  invalidated_at=$(($last_update + $update_timeout))
+  local last_update="$(date -r "$update_timestamp_path" +%s)"
+  local current_timestamp="$(date +%s)"
+  local invalidated_at="$(($last_update + $update_timeout))"
 
   [ $invalidated_at -lt $current_timestamp ]
 }
@@ -50,6 +50,5 @@ install_or_update_perl_build() {
     download_perl_build
   elif should_update; then
     update_perl_build
-    date +%s > "$(update_timestamp_path)"
   fi
 }

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -11,7 +11,7 @@ ensure_perl_build_installed() {
 download_perl_build() {
   echo "Downloading perl-build..." >&2
   local perl_build_url="https://github.com/tokuhirom/Perl-Build.git"
-  git clone $perl_build_url "$(perl_build_checkout)"
+  git clone --depth 1 $perl_build_url "$(perl_build_checkout)"
 }
 
 perl_build_checkout() {


### PR DESCRIPTION
Hi, I actually have a few changes in here and wasn't sure if i should bother opening a separate small PRs or just one to begin the conversation.

The major change here is replacing Perl-Build with https://github.com/skaji/perl-install which does not require a system perl to operate.  Both are plenv plugins so it's almost a drop-in change.  I also removed plenv because it is not used or required.

I switched to perl-install because MacOS has deprecated its bundled scripting languages, and plans to remove them eventually.  This also makes asdf-perl available to minimal environments, like docker images.

The other two changes here are using git itself to track the last update time, rather than a separate file, and only making a shallow clone, which avoids pulling unnecessary data during clone and later updates.  I have not added anything that cleans up old `plenv` directories - I wasn't sure it would be a good idea do that automatically.