### PR TITLE
Support non-default default-perl-modules location

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ asdf plugin add perl https://github.com/ouest/asdf-perl.git
 ## Use
 
 Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions.
+
+## Default perl modules
+
+asdf-perl can automatically install a set of default perl modules right after
+installing a perl version. To enable this feature, provide a
+`$HOME/.default-perl-modules` file that lists one module per line, for example:
+
+```
+App::Ack
+CGI
+HTML::Template
+```
+
+You can specify a non-default location of this file by setting a `ASDF_PERL_DEFAULT_PACKAGES_FILE` variable.

--- a/bin/install
+++ b/bin/install
@@ -33,7 +33,7 @@ install_cpanm() {
 }
 
 install_default_perl_modules() {
-  local default_perl_modules="${HOME}/.default-perl-modules"
+  local default_perl_modules="${ASDF_PERL_DEFAULT_PACKAGES_FILE:=${HOME}/.default-perl-modules}"
 
   if [ ! -f $default_perl_modules ]; then return; fi
 


### PR DESCRIPTION
Hi @ouest,

Thank you for the useful asdf plugin. :pray:

I want to change the location `~/.default-perl-modules` to e.g. `~/.config/asdf/default-perl-modules`. I imitated [asdf-ruby](https://github.com/asdf-vm/asdf-ruby) and [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs).

Best regards.
