### PR TITLE
Add environment variable to optionally display devel perls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ asdf plugin add perl
 
 Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions.
 
+Set the `ASDF_PERL_DEVEL` environment variable to list development versions of Perl in addition to stable versions.
+
 ## Default perl modules
 
 asdf-perl can automatically install a set of default perl modules right after

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,7 +12,7 @@ list_all() {
     list_arg="--list"
   fi
 
-  $(perl_install_bin) $arg \
+  $(perl_install_bin) $list_arg \
     | if which tac >/dev/null; then
       tac
     else

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,11 +4,21 @@ source "$(dirname "$0")/utils.sh"
 
 list_all() {
   install_or_update_perl_install
-  if which tac >/dev/null; then
-    $(perl_install_bin) --list-all | tac | tr '\n' ' '
+
+  local list_arg
+  if [ $ASDF_PERL_DEVEL ]; then
+    list_arg="--list-all"
   else
-    $(perl_install_bin) --list-all | tail -r | tr '\n' ' '
+    list_arg="--list"
   fi
+
+  $(perl_install_bin) $arg \
+    | if which tac >/dev/null; then
+      tac
+    else
+      tail -r
+    fi \
+    | tr '\n' ' '
 }
 
 list_all


### PR DESCRIPTION
Resolves #16.

The environment variable `$ASDF_PERL_DEVEL` allows for displaying all available versions of perl. Without it, `asdf list all perl` will display stable versions.

This also makes `asdf install perl latest` behave as expected, installing the latest stable version instead of a devel version.