### PR TITLE
fix: don't pass empty string to cpanm if ASDF_PERL_CPANM_ARGS is not set

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -54,7 +54,7 @@ install_default_perl_modules() {
 
   while read -r -a name; do
     printf '\nInstalling \033[33m%s\033[39m perl package... ' "${name[*]}"
-    PATH="$ASDF_INSTALL_PATH/bin:$PATH" cpanm "${ASDF_PERL_CPANM_ARGS}" "${name[@]}" >/dev/null 2>&1 && rc=$? || rc=$?
+    PATH="$ASDF_INSTALL_PATH/bin:$PATH" cpanm ${ASDF_PERL_CPANM_ARGS} "${name[@]}" >/dev/null 2>&1 && rc=$? || rc=$?
     if [[ $rc -eq 0 ]]; then
       echo -e "\033[32mSUCCESS\033[39m"
     else

--- a/bin/install
+++ b/bin/install
@@ -60,8 +60,7 @@ install_default_perl_modules() {
 
   while read -r -a name; do
     printf '\nInstalling \033[33m%s\033[39m perl package... ' "${name[*]}"
-    PATH="$ASDF_INSTALL_PATH/bin:$PATH" cpanm "${extra_args[@]}" "${name[@]}" >/dev/null 2>&1 && rc=$? || rc=$?
-    if [[ $rc -eq 0 ]]; then
+    if PATH="$ASDF_INSTALL_PATH/bin:$PATH" cpanm "${extra_args[@]}" "${name[@]}" >/dev/null 2>&1; then
       echo -e "\033[32mSUCCESS\033[39m"
     else
       echo -e "\033[31mFAIL\033[39m"

--- a/bin/install
+++ b/bin/install
@@ -49,12 +49,18 @@ install_cpanm() {
 
 install_default_perl_modules() {
   local default_perl_modules="${ASDF_PERL_DEFAULT_PACKAGES_FILE:=${HOME}/.default-perl-modules}"
+  # ASDF_PERL_CPANM_ARGS is an environment variable, which can't
+  # be an array. We use it to initialize a local array, acknowledging that
+  # depending on whitespace this way may break depending on what the user puts
+  # into it.
+  local extra_args
+  read -r -a extra_args <<<"$ASDF_PERL_CPANM_ARGS"
 
   if [ ! -f "$default_perl_modules" ]; then return; fi
 
   while read -r -a name; do
     printf '\nInstalling \033[33m%s\033[39m perl package... ' "${name[*]}"
-    PATH="$ASDF_INSTALL_PATH/bin:$PATH" cpanm ${ASDF_PERL_CPANM_ARGS} "${name[@]}" >/dev/null 2>&1 && rc=$? || rc=$?
+    PATH="$ASDF_INSTALL_PATH/bin:$PATH" cpanm "${extra_args[@]}" "${name[@]}" >/dev/null 2>&1 && rc=$? || rc=$?
     if [[ $rc -eq 0 ]]; then
       echo -e "\033[32mSUCCESS\033[39m"
     else


### PR DESCRIPTION
The quotes around $ASDF_PERL_CPANM result in an extra empty string being passed to cpanm if the variable is not set, which causes the default module installation to fail.

Fixes #37.