### PR TITLE
Fix asdf-vm/actions/plugin-test version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: perl --help

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v4
 
       - name: Run ShellCheck
         run: scripts/shellcheck.bash
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v4
 
       - name: List file to shfmt
         run: shfmt -f .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: simple

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-shellcheck 0.7.2
+shellcheck 0.10.0
 shfmt 3.3.0

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# This download callback is no-op because perl-install does not provide a way to
+# download Perl without compiling or installing it.


### PR DESCRIPTION
Fix CI: add bin/download callback and update stale actions

All four jobs on this PR were failing for two separate reasons, both reproduced locally with act.

- Add a no-op bin/download. asdf 0.16+ requires this callback, and
  perl-install offers no way to download Perl without also building
  it, so this mirrors asdf-vm/asdf-ruby.
- Bump asdf-vm/actions/install v1 -> v4. v1 clones asdf master and
  expects ~/.asdf/bin/asdf, which no longer exists after the Go
  rewrite, so both lint jobs died before running anything.
- Bump actions/checkout v2 -> v4 to clear the Node 20 deprecation.
 - Move release.yml to googleapis/release-please-action@v4 and add
   the permissions v4 requires.
- Bump shellcheck to 0.10.0.